### PR TITLE
meta data query execution with query executioner

### DIFF
--- a/FieldMetaBuilderSpike.ipynb
+++ b/FieldMetaBuilderSpike.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 55,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -13,7 +13,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 73,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -33,12 +33,11 @@
     "                            for sf in self.subfields])\n",
     "    \n",
     "    def __getattr__(self,k):\n",
-    "        meta = self.internal_exec._get_type_info(self._returnType)\n",
     "        return partial(self.add_subfield,k)\n",
     "    \n",
     "    def __dir__(self):\n",
-    "        meta = self.internal_exec._get_type_info(self._returnType)\n",
-    "        return (super().__dir__() + list(meta.keys()))\n",
+    "        meta = self.internal_exec.get_type_info(self._returnType)\n",
+    "        return (super().__dir__() + list(meta.fields.keys()))\n",
     "            \n",
     "        \n",
     "    @classmethod\n",
@@ -49,7 +48,7 @@
     "        return self.internal_exec._get_type_info(self._returnType)\n",
     "        \n",
     "    def add_subfield(self,field,args = {}):\n",
-    "        possible_fields = self.internal_exec._get_type_info(self._returnType)\n",
+    "        possible_fields = self.internal_exec.get_type_info(self._returnType).fields\n",
     "        return_type = possible_fields[field].get_return_type()\n",
     "        f = Field(field,return_type,args)\n",
     "        self.subfields.append(f)\n",
@@ -66,7 +65,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 76,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -105,7 +104,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 77,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -133,6 +132,343 @@
     "statistic2_2.year()\n",
     "print(query2)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Usefull executioner functionality\n",
+    "To build a complex query builder Field class using meta data the query executioner proveds the  `.get_type_info` method which returns a named tuple."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ex = QueryExecutioner()\n",
+    "stat_info = ex.get_type_info('AENW01')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'OBJECT'"
+      ]
+     },
+     "execution_count": 14,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "stat_info.kind"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'id': {'name': 'id',\n",
+       "  'type': {'ofType': None,\n",
+       "   'kind': 'SCALAR',\n",
+       "   'name': 'String',\n",
+       "   'description': 'The `String` scalar type represents textual data, represented as UTF-8 character sequences. The String type is most often used by GraphQL to represent free-form human-readable text.'},\n",
+       "  'description': 'Interne eindeutige ID',\n",
+       "  'args': []},\n",
+       " 'year': {'name': 'year',\n",
+       "  'type': {'ofType': None,\n",
+       "   'kind': 'SCALAR',\n",
+       "   'name': 'Int',\n",
+       "   'description': 'The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1. '},\n",
+       "  'description': 'Jahr des Stichtages',\n",
+       "  'args': []},\n",
+       " 'value': {'name': 'value',\n",
+       "  'type': {'ofType': None,\n",
+       "   'kind': 'SCALAR',\n",
+       "   'name': 'Float',\n",
+       "   'description': 'The `Float` scalar type represents signed double-precision fractional values as specified by [IEEE 754](https://en.wikipedia.org/wiki/IEEE_floating_point). '},\n",
+       "  'description': 'Wert',\n",
+       "  'args': []},\n",
+       " 'source': {'name': 'source',\n",
+       "  'type': {'ofType': None,\n",
+       "   'kind': 'OBJECT',\n",
+       "   'name': 'Source',\n",
+       "   'description': ''},\n",
+       "  'description': 'Quellenverweis zur GENESIS Regionaldatenbank',\n",
+       "  'args': []}}"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "stat_info.fields"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "stat_info.enum_values"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 26,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "enum_info = ex.get_type_info('WHGGR1')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 27,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('ENUM', None)"
+      ]
+     },
+     "execution_count": 27,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "enum_info.kind,enum_info.fields"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'WHGRME01': 'Wohnungen mit 1 Raum',\n",
+       " 'WHGRME02': 'Wohnungen mit 2 Räumen',\n",
+       " 'WHGRME03': 'Wohnungen mit 3 Räumen',\n",
+       " 'WHGRME04': 'Wohnungen mit 4 Räumen',\n",
+       " 'WHGRME05': 'Wohnungen mit 5 Räumen',\n",
+       " 'WHGRME06': 'Wohnungen mit 6 Räumen',\n",
+       " 'WHGRME07UM': 'Wohnungen mit 7 Räumen oder mehr',\n",
+       " 'GESAMT': 'Gesamt'}"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "enum_info.enum_values"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## FieldMetaDict\n",
+    "In order to improve internal readbility and usability the individual subdicts of the named tuples `.fields` position, are FieldMetaDicts. This is a custom Subclass of Dict that addtionally provides two methods to obtain certain meta information. One is `.get_return_type()` and the second is `.get_arguments`. These are supposed to help with implementations while still keeping all the regular dicitonary functionality in place to cover edge cases and similar.\n",
+    "\n",
+    "### Note on testing with inheritance\n",
+    "Due to subclassing `dict` and the is the following distinction in testing the class of a `FieldMetaDict` instance `x`.\n",
+    "```python\n",
+    "type(x) == dict  #returns false\n",
+    "isinstance(x,dict)  #returns still true\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Return types\n",
+    "`.get_return_type()` type modifiers of the return type like returning a list or elements for instance and always returns only the name of the underlying type of whatever is returned."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "region_info = ex.get_type_info('Region')\n",
+    "query_info = ex.get_type_info('Query')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 30,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'WOHNY1'"
+      ]
+     },
+     "execution_count": 30,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "region_info.fields['WOHNY1'].get_return_type()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('Region', 'RegionsResult')"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "(query_info.fields['region'].get_return_type()\n",
+    " ,query_info.fields['allRegions'].get_return_type())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'String'"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "region_info.fields['id'].get_return_type()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Argument Examples\n",
+    "`.get_arguments` returns a dict of all the arguments as well as some information about them. The information make take a different form depending on the argument being a LIST, NON_NULL or  having no special property. Currently the focus was on simply presenting this information to get a feling for it. Accessing it more systematically and providing more of an interface may come at a later point."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 21,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'year': ('LIST', None, 'Int', 'SCALAR'),\n",
+       " 'statistics': ('LIST', None, 'WOHNY1Statistics', 'ENUM'),\n",
+       " 'WHGGR1': ('LIST', None, 'WHGGR1', 'ENUM'),\n",
+       " 'filter': ('INPUT_OBJECT', 'WOHNY1Filter', None, None)}"
+      ]
+     },
+     "execution_count": 21,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "region_info.fields['WOHNY1'].get_arguments()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 35,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'year': ('LIST', None, 'Int', 'SCALAR'),\n",
+       " 'statistics': ('LIST', None, 'AENW01Statistics', 'ENUM')}"
+      ]
+     },
+     "execution_count": 35,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "region_info.fields['AENW01'].get_arguments()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 24,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'id': ('NON_NULL', None, 'String', 'SCALAR')}"
+      ]
+     },
+     "execution_count": 24,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "query_info.fields['region'].get_arguments()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 25,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'page': ('SCALAR', 'Int', None, None),\n",
+       " 'itemsPerPage': ('SCALAR', 'Int', None, None)}"
+      ]
+     },
+     "execution_count": 25,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "query_info.fields['allRegions'].get_arguments()"
+   ]
   }
  ],
  "metadata": {
@@ -151,7 +487,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.3rc1"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/FieldMetaBuilderSpike.ipynb
+++ b/FieldMetaBuilderSpike.ipynb
@@ -2,21 +2,22 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 55,
    "metadata": {},
    "outputs": [],
    "source": [
     "from datenguide_python.query_execution import QueryExecutioner\n",
-    "import re"
+    "import re\n",
+    "from functools import partial"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 73,
    "metadata": {},
    "outputs": [],
    "source": [
-    "class Field():\n",
+    "class Field(object):\n",
     "    internal_exec = QueryExecutioner()\n",
     "    \n",
     "    def __init__(self,name,return_Type,args=dict()):\n",
@@ -30,6 +31,15 @@
     "        return '\\n'.join([self.name + arg_str] \n",
     "                         + [re.sub(r'(^|\\n)',r'\\1   ',str(sf))\n",
     "                            for sf in self.subfields])\n",
+    "    \n",
+    "    def __getattr__(self,k):\n",
+    "        meta = self.internal_exec._get_type_info(self._returnType)\n",
+    "        return partial(self.add_subfield,k)\n",
+    "    \n",
+    "    def __dir__(self):\n",
+    "        meta = self.internal_exec._get_type_info(self._returnType)\n",
+    "        return (super().__dir__() + list(meta.keys()))\n",
+    "            \n",
     "        \n",
     "    @classmethod\n",
     "    def toplevel(cls):\n",
@@ -48,35 +58,15 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": 12,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "<__main__.Field at 0x7f7611465be0>"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
    "source": [
-    "query = Field.toplevel()\n",
-    "region = query.add_subfield('region',{'id':'01'})\n",
-    "n = region.add_subfield('name')\n",
-    "statistic = region.add_subfield('AENW01')\n",
-    "statistic2 = region.add_subfield('AENW06')\n",
-    "# Scalar fields don't need to be bound to variables as nothing can be done with them\n",
-    "y = statistic.add_subfield('year')\n",
-    "statistic2.add_subfield('year')"
+    "## .add_subfield style adding"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 76,
    "metadata": {},
    "outputs": [
     {
@@ -94,15 +84,55 @@
     }
    ],
    "source": [
+    "query = Field.toplevel()\n",
+    "region = query.add_subfield('region',{'id':'01'})\n",
+    "n = region.add_subfield('name')\n",
+    "statistic = region.add_subfield('AENW01')\n",
+    "statistic2 = region.add_subfield('AENW06')\n",
+    "# Scalar fields don't need to be bound to variables as nothing can be done with them\n",
+    "y = statistic.add_subfield('year')\n",
+    "statistic2.add_subfield('year')\n",
     "print(query)"
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "## `__getattr__` style adding\n",
+    "This is also supported by the `__dir__` implementation of the class"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 77,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "query\n",
+      "   region{'id': '01'}\n",
+      "      name\n",
+      "      AENW01\n",
+      "         year\n",
+      "      AENW06\n",
+      "         year\n"
+     ]
+    }
+   ],
+   "source": [
+    "query2 = Field.toplevel()\n",
+    "region2 = query2.region({'id':'01'})\n",
+    "n = region2.add_subfield('name') #namin conflict with attribute name of the field\n",
+    "statistic_2 = region2.AENW01()\n",
+    "statistic2_2 = region2.AENW06()\n",
+    "# Scalar fields don't need to be bound to variables as nothing can be done with them\n",
+    "y = statistic_2.year()\n",
+    "statistic2_2.year()\n",
+    "print(query2)"
+   ]
   }
  ],
  "metadata": {

--- a/FieldMetaBuilderSpike.ipynb
+++ b/FieldMetaBuilderSpike.ipynb
@@ -1,0 +1,129 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from datenguide_python.query_execution import QueryExecutioner\n",
+    "import re"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class Field():\n",
+    "    internal_exec = QueryExecutioner()\n",
+    "    \n",
+    "    def __init__(self,name,return_Type,args=dict()):\n",
+    "        self.name = name\n",
+    "        self.subfields = []\n",
+    "        self.args = args\n",
+    "        self._returnType = return_Type\n",
+    "        \n",
+    "    def __str__(self):\n",
+    "        arg_str = str(self.args) if len(self.args) > 0 else ''\n",
+    "        return '\\n'.join([self.name + arg_str] \n",
+    "                         + [re.sub(r'(^|\\n)',r'\\1   ',str(sf))\n",
+    "                            for sf in self.subfields])\n",
+    "        \n",
+    "    @classmethod\n",
+    "    def toplevel(cls):\n",
+    "        return cls('query','Query')\n",
+    "    \n",
+    "    def info(self):\n",
+    "        return self.internal_exec._get_type_info(self._returnType)\n",
+    "        \n",
+    "    def add_subfield(self,field,args = {}):\n",
+    "        possible_fields = self.internal_exec._get_type_info(self._returnType)\n",
+    "        return_type = possible_fields[field].get_return_type()\n",
+    "        f = Field(field,return_type,args)\n",
+    "        self.subfields.append(f)\n",
+    "        return f\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<__main__.Field at 0x7f7611465be0>"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "query = Field.toplevel()\n",
+    "region = query.add_subfield('region',{'id':'01'})\n",
+    "n = region.add_subfield('name')\n",
+    "statistic = region.add_subfield('AENW01')\n",
+    "statistic2 = region.add_subfield('AENW06')\n",
+    "# Scalar fields don't need to be bound to variables as nothing can be done with them\n",
+    "y = statistic.add_subfield('year')\n",
+    "statistic2.add_subfield('year')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "query\n",
+      "   region{'id': '01'}\n",
+      "      name\n",
+      "      AENW01\n",
+      "         year\n",
+      "      AENW06\n",
+      "         year\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(query)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "datenguide",
+   "language": "python",
+   "name": "datenguide"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3rc1"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/datenguide_python/query_execution.py
+++ b/datenguide_python/query_execution.py
@@ -1,4 +1,4 @@
-from typing import Dict, Any, cast, Optional, NamedTuple, List
+from typing import Dict, Any, cast, Optional, NamedTuple, List, Tuple
 import requests
 import re
 
@@ -11,11 +11,36 @@ class ExecutionResults(NamedTuple):
 
 
 class FieldMetaDict(dict):
-    def get_return_type(self):
+    def get_return_type(self) -> str:
         if self["type"]["kind"] == "LIST":
             return self["type"]["ofType"]["name"]
         else:
             return self["type"]["name"]
+
+    def get_arguments(self) -> List[Tuple[Optional[str], ...]]:
+        def get_type_of(
+            argument: Dict[str, Any]
+        ) -> Tuple[Optional[str], Optional[str]]:
+            if argument["type"]["ofType"]:
+                return (
+                    argument["type"]["ofType"]["name"],
+                    argument["type"]["ofType"]["kind"],
+                )
+            else:
+                return None, None
+
+        return list(
+            (
+                cast(Optional[str], arg.get("name")),
+                cast(Optional[str], arg.get("type", {}).get("kind", {})),
+                cast(Optional[str], arg.get("type", {}).get("name")),
+                *get_type_of(arg),
+            )
+            for arg in self["args"]
+        )
+
+    def get_enumValues(self) -> List[Json]:
+        return self["enumValues"]
 
 
 class QueryExecutioner(object):
@@ -24,25 +49,12 @@ class QueryExecutioner(object):
 
     _META_DATA_CACHE: Json = dict()
 
-    _meta_data_query_json: Dict[str, str] = {
-        "query": r"""{
-          __type(name: "Region") {
-            fields {
-              name
-              description
-              args {
-                name
-              }
-            }
-          }
-        }"""
-    }
-
-    _meta_type_info = """
+    _meta_type_info: str = """
         query TypeInfo($type: String!) {
       __type(name: $type) {
         fields {
           name
+          enumValues
           type {
             ofType {
               name
@@ -93,34 +105,36 @@ class QueryExecutioner(object):
         else:
             return None
 
-    def _get_type_info(self, type):
-        if type in self.__class__._META_DATA_CACHE:
-            return self.__class__._META_DATA_CACHE[type]
-        variables = {"type": type}
-        query_json = {}
+    def get_type_info(self, graph_ql_type: str) -> Optional[Json]:
+        if graph_ql_type in self.__class__._META_DATA_CACHE:
+            print("use cache")
+            return self.__class__._META_DATA_CACHE[graph_ql_type]
+        variables: Dict[str, str] = {"type": graph_ql_type}
+        query_json: Json = {}
         query_json["query"] = self._meta_type_info
         query_json["variables"] = variables
+        print("query database")
         info = self._send_request(query_json)
         if info:
             type_meta = {
                 f["name"]: FieldMetaDict(f) for f in info["data"]["__type"]["fields"]
             }
-            self.__class__._META_DATA_CACHE[type] = type_meta
+            self.__class__._META_DATA_CACHE[graph_ql_type] = type_meta
             return type_meta
         else:
-            None
+            return None
 
     @staticmethod
     def _generate_post_json(
         query, variables=Optional[Dict[str, str]]
     ) -> Dict[str, str]:
-        post_json = dict()
+        post_json: Json = dict()
         post_json["query"] = query.get_graphql_query()
         if variables:
             post_json["variables"] = cast(Dict[str, str], variables)
         return post_json
 
-    def _send_request(self, query_json: Dict[str, str]) -> Optional[Json]:
+    def _send_request(self, query_json: Json) -> Optional[Json]:
         resp = requests.post(
             self.endpoint, headers=self.REQUEST_HEADER, json=query_json
         )
@@ -131,7 +145,7 @@ class QueryExecutioner(object):
             return None
 
     def _get_stats_meta_data(self) -> Optional[Json]:
-        return self._send_request(self._meta_data_query_json)
+        return self.get_type_info("Region")
 
     @staticmethod
     def _process_stat_meta_data(raw_response: Json) -> List[Json]:

--- a/datenguide_python/query_execution.py
+++ b/datenguide_python/query_execution.py
@@ -10,6 +10,12 @@ class ExecutionResults(NamedTuple):
     meta_data: Json
 
 
+class TypeMetaData(NamedTuple):
+    kind: str
+    fields: Optional[Json]
+    enum_values: Optional[Dict[str, str]]
+
+
 class FieldMetaDict(dict):
     def get_return_type(self) -> str:
         if self["type"]["kind"] == "LIST":
@@ -17,30 +23,26 @@ class FieldMetaDict(dict):
         else:
             return self["type"]["name"]
 
-    def get_arguments(self) -> List[Tuple[Optional[str], ...]]:
+    def get_arguments(self) -> Dict[str, Tuple[Optional[str], ...]]:
         def get_type_of(
             argument: Dict[str, Any]
         ) -> Tuple[Optional[str], Optional[str]]:
             if argument["type"]["ofType"]:
                 return (
-                    argument["type"]["ofType"]["name"],
                     argument["type"]["ofType"]["kind"],
+                    argument["type"]["ofType"]["name"],
                 )
             else:
                 return None, None
 
-        return list(
-            (
-                cast(Optional[str], arg.get("name")),
+        return {
+            cast(str, arg["name"]): (
                 cast(Optional[str], arg.get("type", {}).get("kind", {})),
                 cast(Optional[str], arg.get("type", {}).get("name")),
                 *get_type_of(arg),
             )
             for arg in self["args"]
-        )
-
-    def get_enumValues(self) -> List[Json]:
-        return self["enumValues"]
+        }
 
 
 class QueryExecutioner(object):
@@ -51,34 +53,38 @@ class QueryExecutioner(object):
 
     _meta_type_info: str = """
         query TypeInfo($type: String!) {
-      __type(name: $type) {
-        fields {
-          name
-          enumValues
-          type {
-            ofType {
-              name
-            }
+          __type(name: $type) {
             kind
-            name
-            description
-          }
-          description
-          args {
-            name
-            type {
-              kind
+            enumValues {
               name
-              ofType {
+              description
+            }
+            fields {
+              name
+              type {
+                ofType {
+                  name
+                }
+                kind
                 name
                 description
-                kind
+              }
+              description
+              args {
+                name
+                type {
+                  kind
+                  name
+                  ofType {
+                    name
+                    description
+                    kind
+                  }
+                }
               }
             }
           }
         }
-      }
-    }
     """
 
     def __init__(self, alternative_endpoint: Optional[str] = None) -> None:
@@ -89,10 +95,12 @@ class QueryExecutioner(object):
         query_json = self._generate_post_json(query)
         results = self._send_request(query_json)
         if results:
-            raw_stat_meta = self._get_stats_meta_data()
-            if raw_stat_meta:
-                stat_descriptions = QueryExecutioner._create_stat_desc_dic(
-                    cast(Json, raw_stat_meta)
+            # Region type contains all the statistics fields
+            stat_meta = self.get_type_info("Region")
+            if stat_meta:
+                stat_descriptions = self._create_stat_desc_dic(
+                    # casting given "Regions" type
+                    cast(Json, cast(TypeMetaData, stat_meta).fields)
                 )
                 meta = {
                     stat: stat_descriptions[stat]
@@ -105,20 +113,43 @@ class QueryExecutioner(object):
         else:
             return None
 
-    def get_type_info(self, graph_ql_type: str) -> Optional[Json]:
+    def get_type_info(
+        self, graph_ql_type: str, verbose=False
+    ) -> Optional[TypeMetaData]:
+        """
+            Returns a json which at top level is a dict with all the
+            fields of the type
+        """
         if graph_ql_type in self.__class__._META_DATA_CACHE:
-            print("use cache")
+            if verbose:
+                print("use cache")
             return self.__class__._META_DATA_CACHE[graph_ql_type]
-        variables: Dict[str, str] = {"type": graph_ql_type}
+        variables = {"type": graph_ql_type}
         query_json: Json = {}
         query_json["query"] = self._meta_type_info
         query_json["variables"] = variables
-        print("query database")
+        if verbose:
+            print("query REST API")
         info = self._send_request(query_json)
         if info:
-            type_meta = {
-                f["name"]: FieldMetaDict(f) for f in info["data"]["__type"]["fields"]
-            }
+            type_kind = info["data"]["__type"]["kind"]
+
+            if type_kind == "OBJECT":
+                field_meta: Optional[Json] = {
+                    f["name"]: FieldMetaDict(f)
+                    for f in info["data"]["__type"]["fields"]
+                }
+            else:
+                field_meta = None
+
+            if type_kind == "ENUM":
+                enum_vals: Optional[Dict[str, str]] = {
+                    value["name"]: value["description"]
+                    for value in info["data"]["__type"]["enumValues"]
+                }
+            else:
+                enum_vals = None
+            type_meta = TypeMetaData(type_kind, field_meta, enum_vals)
             self.__class__._META_DATA_CACHE[graph_ql_type] = type_meta
             return type_meta
         else:
@@ -126,7 +157,7 @@ class QueryExecutioner(object):
 
     @staticmethod
     def _generate_post_json(
-        query, variables=Optional[Dict[str, str]]
+        query, variables: Optional[Dict[str, str]] = None
     ) -> Dict[str, str]:
         post_json: Json = dict()
         post_json["query"] = query.get_graphql_query()
@@ -141,21 +172,16 @@ class QueryExecutioner(object):
         if resp.status_code == 200:
             return resp.json()
         else:
+            print(self.endpoint)
             print(f"No result, got HTML status code {resp.status_code}")
             return None
 
-    def _get_stats_meta_data(self) -> Optional[Json]:
-        return self.get_type_info("Region")
-
     @staticmethod
-    def _process_stat_meta_data(raw_response: Json) -> List[Json]:
-        def contains_statistic(args: List[Json]):
-            return any(arg["name"] == "statistics" for arg in args)
-
+    def _process_stat_meta_data(type_fields: Json) -> List[Json]:
         return [
-            field
-            for field in raw_response["data"]["__type"]["fields"]
-            if contains_statistic(field["args"])
+            type_fields[name]
+            for name in type_fields
+            if "statistics" in type_fields[name].get_arguments()
         ]
 
     @staticmethod

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -99,3 +99,32 @@ def test_QueryExecutionerWorkflow(sample_queries):
     # he actually wants to try a larger one across several regions. He heard
     # that this might be an issue for the server in general, but that the
     # executioner takes care of addressing this issue by itself.
+
+    # IMPLEMENT ON QUERY BUILDER SIDE?
+
+    # so far everything has been quite nice but Ira feels a little
+    # lost with all the types and arguments. But he knows that the
+    # executioner can actually give information on types and Ira
+    # happens to know that the type of region queries is "Region"
+    # and he tries to gen info on it.
+
+    info = qExec.get_type_info("Region")
+    assert info.kind == "OBJECT", "Region should be an object"
+    assert info.enum_values is None, "Region doesn't have enum values"
+    assert type(info.fields) == dict, "Fields should be a dict"
+
+    # Since this is a lot of information Ira would particularly
+    # like to drill down on the arguments that are allowed for his
+    # favorite statistic BEVMK3
+
+    stat_args = info.fields["BEVMK3"].get_arguments()
+    assert len(stat_args) > 0
+    assert "statistics" in stat_args
+
+    # Although this is already really helpfull Ira notices that
+    # one of the arguments is an ENUM and he would like to know
+    # the possible values that he can use for it.
+
+    enum_vals = qExec.get_type_info("BEVMK3Statistics").enum_values
+    assert type(enum_vals) == dict, "Enum values should be dict"
+    assert len(enum_vals) > 0, "Enums should have values"


### PR DESCRIPTION
This pull request contains basic functionality of the query executioner to get execute meta data queries against the database and provide results of these queries for other parts of the module, in particular the query builder. The functionality includes a global meta data cache in the query executioner to avoid redundant API requests in particular of the Regions type, which contains a lot of information for the GraphQL API in question.

There is also an example Notebook included with a spike of how the meta data could be used in query building and how meta data can be accessed in general using the new functionalities.