### PR TITLE
Field: return_type, default values and get_info

### DIFF
--- a/datenguide_python/query_builder.py
+++ b/datenguide_python/query_builder.py
@@ -1,4 +1,3 @@
-from __future__ import annotations
 from typing import Optional, Union, List, Dict
 from datenguide_python.query_execution import (
     QueryExecutioner,
@@ -29,7 +28,7 @@ class Field:
     def __init__(
         self,
         name: str,
-        fields: List[Union[str, Field]] = [],
+        fields: List[Union[str, object]] = [],
         args: Optional[Dict[str, Union[str, List[str]]]] = None,
     ):
 
@@ -40,7 +39,7 @@ class Field:
     def __eq__(self, other):
         return self.__dict__ == other.__dict__
 
-    def add_field(self, field: Union[str, "Field"]) -> Field:
+    def add_field(self, field: Union[str, "Field"]) -> object:
         if isinstance(field, str):
             added_field = Field(name=field)
         else:
@@ -123,7 +122,7 @@ class Query:
             fields_string += self._get_fields_to_query_helper(field)
         return fields_string.strip()
 
-    def _get_fields_to_query_helper(self, field: Union[str, Field]) -> str:
+    def _get_fields_to_query_helper(self, field: Union[str, object]) -> str:
         substring = ""
         if isinstance(field, str):
             substring += field + " "
@@ -219,7 +218,7 @@ class Query:
         return QueryExecutioner().run_query(self)
 
     @staticmethod
-    def _get_fields_helper(field: Union[str, Field]) -> List[str]:
+    def _get_fields_helper(field: Union[str, object]) -> List[str]:
         field_list = []
         if isinstance(field, str):
             field_list.append(field)

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -1,49 +1,18 @@
-from unittest.mock import Mock
-from collections import namedtuple
 import pytest
 
 
 from datenguide_python.query_execution import QueryExecutioner
+from datenguide_python.query_builder import Query, Field
 
 
 @pytest.fixture
-def sample_queries():
-    q1 = Mock()
-    q1.get_graphql_query.return_value = """
-    {
-        region(id:"05911") {
-            id
-            name
-            BEVMK3 {
-                value
-                year
-            }
-        }
-    }
-    """
-    q1.get_fields.return_value = ["region", "id", "name", "BEVMK3", "value", ".year"]
-
-    mq1 = Mock()
-    mq1.get_graphql_query.return_value = """
-    {
-      __type(name: "Region") {
-        name
-        fields {
-          name
-          description
-          type {
-            name
-            kind
-          }
-        }
-      }
-    }
-    """
-    SampleQueries = namedtuple("SampleQueries", "data_query1 meta_query1")
-    return SampleQueries(q1, mq1)
+def query():
+    field = Field(name="BEVMK3", fields=["value", "year"])
+    query = Query(region="05911", fields=["id", "name", field])
+    return query
 
 
-def test_QueryExecutionerWorkflow(sample_queries):
+def test_QueryExecutionerWorkflow(query):
     """Functional test for the query executioner"""
 
     # Ira (W. Cotton, probably the first person to use the term API) want to
@@ -67,7 +36,8 @@ def test_QueryExecutionerWorkflow(sample_queries):
     # now wants to execute one of his queries to see that he gets some return
     # values.
 
-    res_query1 = qExec.run_query(sample_queries.data_query1)
+    res_query1 = query.results()
+
     assert res_query1 is not None, "query did not return results"
 
     # He wants to have a closer look at the raw return query results and
@@ -77,6 +47,14 @@ def test_QueryExecutionerWorkflow(sample_queries):
     assert (
         type(res_query1.query_results) is dict
     ), "query results are not a python json representation"
+
+    # Ira wants to get an overview of all possible statistics that can be
+    # queried.
+
+    stats = Query.get_info()
+    assert stats.kind == "OBJECT", "Region should be an object"
+    assert stats.enum_values is None, "Region doesn't have enum values"
+    assert type(stats.fields) == dict, "Fields should be a dict"
 
     # Ira remembers that he read about the executioners functionality to
     # return metadata along with the query results. So he wants to check
@@ -100,31 +78,31 @@ def test_QueryExecutionerWorkflow(sample_queries):
     # that this might be an issue for the server in general, but that the
     # executioner takes care of addressing this issue by itself.
 
-    # IMPLEMENT ON QUERY BUILDER SIDE?
-
-    # so far everything has been quite nice but Ira feels a little
-    # lost with all the types and arguments. But he knows that the
-    # executioner can actually give information on types and Ira
-    # happens to know that the type of region queries is "Region"
-    # and he tries to gen info on it.
-
-    info = qExec.get_type_info("Region")
-    assert info.kind == "OBJECT", "Region should be an object"
-    assert info.enum_values is None, "Region doesn't have enum values"
-    assert type(info.fields) == dict, "Fields should be a dict"
-
     # Since this is a lot of information Ira would particularly
     # like to drill down on the arguments that are allowed for his
     # favorite statistic BEVMK3
 
-    stat_args = info.fields["BEVMK3"].get_arguments()
+    stat_args = stats.fields["BEVMK3"].get_arguments()
     assert len(stat_args) > 0
     assert "statistics" in stat_args
 
-    # Although this is already really helpfull Ira notices that
+    # Although this is already really helpful Ira notices that
     # one of the arguments is an ENUM and he would like to know
     # the possible values that he can use for it.
 
-    enum_vals = qExec.get_type_info("BEVMK3Statistics").enum_values
+    enum_vals = Query.get_info("BEVMK3Statistics").enum_values
     assert type(enum_vals) == dict, "Enum values should be dict"
     assert len(enum_vals) > 0, "Enums should have values"
+
+    # Ira wants to add another statistic to his query.
+    statistic1 = query.add_field("BEV001")
+    statistic1.add_field("year")
+    statistic1.add_args({"year": 2017})
+
+    assert type(statistic1) == Field, "statistic is not a Field"
+
+    # Then he wants to get metainfo on the field.
+
+    stats_info = statistic1.get_info()
+    assert stats_info.kind == "OBJECT", "BEV001 should be an object"
+    assert type(stats_info.fields) == dict, "Fields should be a dict"

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -8,7 +8,7 @@ from datenguide_python.query_builder import Query, Field
 @pytest.fixture
 def query():
     field = Field(name="BEVMK3", fields=["value", "year"])
-    query = Query(region="05911", fields=["id", "name", field])
+    query = Query.regionQuery(region="05911", fields=["id", "name", field])
     return query
 
 

--- a/tests/test_query_builder.py
+++ b/tests/test_query_builder.py
@@ -291,9 +291,6 @@ def test_add_fields_stepwise():
         ],
         default_fields=False,
     )
-
-    print(query)
-    print(query2)
     assert query.get_graphql_query() == query2.get_graphql_query()
 
     graphql_query = query.get_graphql_query()
@@ -305,6 +302,27 @@ def test_add_fields_stepwise():
                     BEV001 {year }
                     WAHL09 (year: 2017, filter:{ PART04: { nin: []}}){value PART04 }
                 }
+        }""".replace(
+            "\n", ""
+        ),
+    )
+
+
+def test_add_fields_all_regions():
+    all_reg_query = Query.allRegionsQuery(parent="11")
+    all_reg_query.add_field("BEV001")
+
+    graphql_query = all_reg_query.get_graphql_query()
+    assert graphql_query == re.sub(
+        "    ",
+        "",
+        """{
+            allRegions (page: $page, itemsPerPage: $itemsPerPage){
+                regions (parent: "11"){
+                    id name BEV001 {
+                        year value source {title_de valid_from periodicity name url }}
+                }
+                page itemsPerPage total }
         }""".replace(
             "\n", ""
         ),

--- a/tests/test_query_builder.py
+++ b/tests/test_query_builder.py
@@ -4,60 +4,50 @@ from datenguide_python import Field, Query
 
 
 @pytest.fixture
-def field():
-    return Field("WAHL09", args={"year": 2017}, fields=["value", "year", "PART04"])
+def field_default():
+    return Field("WAHL09", args={"year": 2017}, fields=["PART04"], return_type="WAHL09")
 
 
 @pytest.fixture
-def query():
+def query_default():
     return Query.regionQuery(region="09", fields=["BEV001"])
 
 
 @pytest.fixture
+def field():
+    return Field(
+        "WAHL09",
+        args={"year": 2017},
+        fields=["value", "year", "PART04"],
+        default_fields=False,
+        return_type="WAHL09",
+    )
+
+
+@pytest.fixture
+def query():
+    return Query.regionQuery(region="09", fields=["BEV001"], default_fields=False)
+
+
+@pytest.fixture
 def complex_query(field):
-    return Query.regionQuery(region="09", fields=["id", "name", field])
+    return Query.regionQuery(
+        region="09", fields=["id", "name", field], default_fields=False
+    )
 
 
 @pytest.fixture
 def more_complex_query(complex_query):
     query = complex_query
-    source = Field("source", fields=["title_de"])
+    source = Field("source", fields=["title_de"], return_type="Source")
     statistic2 = Field(
-        name="BEV001", args={"statistics": "R12612"}, fields=["value", "year", source]
+        name="BEV001",
+        args={"statistics": "R12612"},
+        fields=["value", "year", source],
+        default_fields=False,
     )
     query.add_field(statistic2)
     return query
-
-
-@pytest.fixture
-def no_args_query():
-    field = Field(name="WAHL09", fields=["value"])
-    return Query.regionQuery(region="09", fields=["id", "name", field])
-
-
-@pytest.fixture
-def multiple_args_query():
-    statistic1 = Field(
-        name="BETR09",
-        args={"FRUNW2": ["FRUART0111", "FRUART0112"]},
-        fields=["FRUNW2", "value", "year"],
-    )
-    return Query.regionQuery(region="02", fields=[statistic1])
-
-
-@pytest.fixture
-def all_regions_query(field):
-    return Query.allRegionsQuery(parent="11", fields=["id", "name", field])
-
-
-@pytest.fixture
-def nuts_query(field):
-    return Query.allRegionsQuery(parent="11", nuts=3, fields=["id", "name", field])
-
-
-@pytest.fixture
-def lau_query(field):
-    return Query.allRegionsQuery(parent="11", lau=3, fields=["id", "name", field])
 
 
 def test_create_query_is_class_query(query):
@@ -71,25 +61,30 @@ def test_create_query_class_without_start_filed_raises_error():
 
 def test_basic_graphql_string(query):
     graphql_query = query.get_graphql_query()
-    assert re.sub(" +", " ", graphql_query.replace("\n", " ")) == re.sub(
-        " +", " ", """{region(id: "09"){BEV001 }}""".replace("\n", " ")
+    assert graphql_query == re.sub(
+        " +", " ", """{region (id: "09"){BEV001 }}""".replace("\n", " ")
     )
 
 
 def test_get_fields_to_query():
-    field = Field(name="WAHL09", args={"year": 2017}, fields=["value", "PART04"])
+    field = Field(
+        name="WAHL09",
+        args={"year": 2017},
+        fields=["value", "PART04"],
+        default_fields=False,
+    )
     subfields_string = field._get_fields_to_query(field)
-    assert subfields_string == "WAHL09(year: 2017){value PART04 }"
+    assert subfields_string == "WAHL09 (year: 2017){value PART04 }"
 
 
 def test_get_complex_graphql_string(complex_query):
     graphql_query = complex_query.get_graphql_query()
-    assert re.sub(" +", " ", graphql_query.replace("\n", " ")) == re.sub(
+    assert graphql_query == re.sub(
         "    ",
         "",
         """{
-            region(id: "09"){
-                id name WAHL09(year: 2017){value year PART04 }
+            region (id: "09"){
+                id name WAHL09 (year: 2017){value year PART04 }
                 }
             }""".replace(
             "\n", ""
@@ -97,14 +92,19 @@ def test_get_complex_graphql_string(complex_query):
     )
 
 
-def test_get_complex_graphql_string_without_args(no_args_query):
+def test_get_complex_graphql_string_without_args():
+    field = Field(name="WAHL09", fields=["value"], default_fields=False)
+    no_args_query = Query.regionQuery(
+        region="09", fields=["id", "name", field], default_fields=False
+    )
+
     graphql_query = no_args_query.get_graphql_query()
-    assert re.sub(" +", " ", graphql_query.replace("\n", " ")) == re.sub(
+    assert graphql_query == re.sub(
         "    ",
         "",
         """{
-        region(id: "09"){
-            id name WAHL09{value }}
+        region (id: "09"){
+            id name WAHL09 {value }}
             }""".replace(
             "\n", ""
         ),
@@ -113,13 +113,13 @@ def test_get_complex_graphql_string_without_args(no_args_query):
 
 def test_get_multiple_stats(more_complex_query):
     graphql_query = more_complex_query.get_graphql_query()
-    assert re.sub(" +", " ", graphql_query.replace("\n", " ")) == re.sub(
+    assert graphql_query == re.sub(
         "    ",
         "",
         """{
-        region(id: "09"){
-            id name WAHL09(year: 2017){value year PART04 }
-            BEV001(statistics: R12612){value year source{title_de }}}
+        region (id: "09"){
+            id name WAHL09 (year: 2017){value year PART04 }
+            BEV001 (statistics: R12612){value year source {title_de }}}
         }""".replace(
             "\n", ""
         ),
@@ -147,14 +147,24 @@ def test_get_all_fields_complex(more_complex_query):
     ]
 
 
-def test_multiple_filter_args(multiple_args_query):
+def test_multiple_filter_args():
+    statistic1 = Field(
+        name="BETR09",
+        args={"FRUNW2": ["FRUART0111", "FRUART0112"]},
+        fields=["FRUNW2", "value", "year"],
+        default_fields=False,
+    )
+    multiple_args_query = Query.regionQuery(
+        region="02", fields=[statistic1], default_fields=False
+    )
+
     graphql_query = multiple_args_query.get_graphql_query()
-    assert re.sub(" +", " ", graphql_query.replace("\n", " ")) == re.sub(
+    assert graphql_query == re.sub(
         "    ",
         "",
         """{
-            region(id: "02"){
-                BETR09(FRUNW2: [FRUART0111, FRUART0112]){FRUNW2 value year }
+            region (id: "02"){
+                BETR09 (FRUNW2: [FRUART0111, FRUART0112]){FRUNW2 value year }
                 }
             }""".replace(
             "\n", ""
@@ -162,16 +172,18 @@ def test_multiple_filter_args(multiple_args_query):
     )
 
 
-def test_all_regions(all_regions_query):
-
+def test_all_regions(field):
+    all_regions_query = Query.allRegionsQuery(
+        parent="11", fields=["id", "name", field], default_fields=False
+    )
     graphql_query = all_regions_query.get_graphql_query()
-    assert re.sub(" +", " ", graphql_query.replace("\n", " ")) == re.sub(
+    assert graphql_query == re.sub(
         "    ",
         "",
         """{
-            allRegions(page: $page, itemsPerPage: $itemsPerPage){
-                regions(parent: "11"){
-                    id name WAHL09(year: 2017){
+            allRegions (page: $page, itemsPerPage: $itemsPerPage){
+                regions (parent: "11"){
+                    id name WAHL09 (year: 2017){
                         value year PART04 }
                 }
                 page itemsPerPage total }
@@ -181,16 +193,19 @@ def test_all_regions(all_regions_query):
     )
 
 
-def test_nuts(nuts_query):
-    query = nuts_query
+def test_nuts(field):
+    query = Query.allRegionsQuery(
+        parent="11", nuts=3, fields=["id", "name", field], default_fields=False
+    )
+
     graphql_query = query.get_graphql_query()
-    assert re.sub(" +", " ", graphql_query.replace("\n", " ")) == re.sub(
+    assert graphql_query == re.sub(
         "    ",
         "",
         """{
-            allRegions(page: $page, itemsPerPage: $itemsPerPage){
-                regions(parent: "11", nuts: 3){
-                    id name WAHL09(year: 2017){value year PART04 }
+            allRegions (page: $page, itemsPerPage: $itemsPerPage){
+                regions (parent: "11", nuts: 3){
+                    id name WAHL09 (year: 2017){value year PART04 }
                 }
                 page itemsPerPage total }
         }""".replace(
@@ -199,16 +214,18 @@ def test_nuts(nuts_query):
     )
 
 
-def test_lau(lau_query):
-    query = lau_query
+def test_lau(field):
+    query = Query.allRegionsQuery(
+        parent="11", lau=3, fields=["id", "name", field], default_fields=False
+    )
     graphql_query = query.get_graphql_query()
     assert re.sub(" +", " ", graphql_query.replace("\n", " ")) == re.sub(
         "    ",
         "",
         """{
-            allRegions(page: $page, itemsPerPage: $itemsPerPage){
-                regions(parent: "11", lau: 3){
-                    id name WAHL09(year: 2017){value year PART04 }
+            allRegions (page: $page, itemsPerPage: $itemsPerPage){
+                regions (parent: "11", lau: 3){
+                    id name WAHL09 (year: 2017){value year PART04 }
                 }
                 page itemsPerPage total }
         }""".replace(
@@ -219,16 +236,20 @@ def test_lau(lau_query):
 
 def test_filter_for_all(query):
     field = Field(
-        name="WAHL09", args={"year": 2017, "PART04": "ALL"}, fields=["value", "PART04"]
+        name="WAHL09",
+        args={"year": 2017, "PART04": "ALL"},
+        fields=["value", "PART04"],
+        default_fields=False,
+        return_type="WAHL09",
     )
     query = Query.regionQuery(region="09", fields=["id", "name", field])
     graphql_query = query.get_graphql_query()
-    assert re.sub(" +", " ", graphql_query.replace("\n", " ")) == re.sub(
+    assert graphql_query == re.sub(
         "    ",
         "",
         """{
-            region(id: "09"){
-                id name WAHL09(
+            region (id: "09"){
+                id name WAHL09 (
                     year: 2017, filter:{ PART04: { nin: []}}){
                         value PART04 }
                 }
@@ -239,34 +260,50 @@ def test_filter_for_all(query):
 
 
 def test_add_fields_stepwise():
-    query = Query.regionQuery(region="11")
-    statistic1 = query.add_field("BEV001")
+    query = Query.regionQuery(region="11", default_fields=False)
+    statistic1 = query.add_field("BEV001", default_fields=False)
     statistic1.add_field("year")
     statistic2 = Field(
-        name="WAHL09", args={"year": 2017, "PART04": "ALL"}, fields=["value", "PART04"]
+        name="WAHL09",
+        args={"year": 2017, "PART04": "ALL"},
+        fields=["value", "PART04"],
+        default_fields=False,
+        return_type="WAHL09",
     )
     query.add_field(statistic2)
 
-    assert query == Query.regionQuery(
+    query2 = Query.regionQuery(
         region="11",
         fields=[
-            Field(name="BEV001", fields=[Field(name="year")]),
+            Field(
+                name="BEV001",
+                fields=["year"],
+                default_fields=False,
+                return_type="BEV001",
+            ),
             Field(
                 name="WAHL09",
                 args={"year": 2017, "PART04": "ALL"},
                 fields=["value", "PART04"],
+                default_fields=False,
+                return_type="WAHL09",
             ),
         ],
+        default_fields=False,
     )
 
+    print(query)
+    print(query2)
+    assert query.get_graphql_query() == query2.get_graphql_query()
+
     graphql_query = query.get_graphql_query()
-    assert re.sub(" +", " ", graphql_query.replace("\n", " ")) == re.sub(
+    assert graphql_query == re.sub(
         "    ",
         "",
         """{
-                region(id: "11"){
-                    BEV001{year}
-                    WAHL09(year: 2017, filter:{ PART04: { nin: []}}){value PART04 }
+                region (id: "11"){
+                    BEV001 {year }
+                    WAHL09 (year: 2017, filter:{ PART04: { nin: []}}){value PART04 }
                 }
         }""".replace(
             "\n", ""
@@ -280,7 +317,31 @@ def test_add_args_stepwise():
     statistic1.add_field("year")
     statistic1.add_args({"year": 2017})
 
-    assert query == Query.regionQuery(
-        region="11",
-        fields=[Field(name="BEV001", args={"year": 2017}, fields=[Field(name="year")])],
+    query2 = Query.regionQuery(
+        region="11", fields=[Field(name="BEV001", args={"year": 2017}, fields=["year"])]
     )
+
+    assert query.get_graphql_query() == query2.get_graphql_query()
+
+
+def test_default_fields(query_default):
+    graphql_query = query_default.get_graphql_query()
+    assert graphql_query == re.sub(
+        "    ",
+        "",
+        """{region (id: "09"){id name BEV001
+            {year value source
+            {title_de valid_from periodicity name url }}}}""".replace(
+            "\n", " "
+        ),
+    )
+
+
+def test_get_all_stats_info():
+    info = Query.get_info()
+    assert "name" in info.fields
+
+
+def test_get_field_info():
+    info = Query.get_info("BEV001")
+    assert "BEVM01" in info.fields

--- a/tests/test_query_builder.py
+++ b/tests/test_query_builder.py
@@ -1,293 +1,257 @@
 import pytest
 import re
-import datenguide_python as dg
+from datenguide_python import Field, Query
+
+
+@pytest.fixture
+def field():
+    return Field("WAHL09", args={"year": 2017}, fields=["value", "year", "PART04"])
 
 
 @pytest.fixture
 def query():
-    return dg.Query(region="09", fields=["BEV001"])
+    return Query.regionQuery(region="09", fields=["BEV001"])
 
 
 @pytest.fixture
-def complex_query():
-    source = dg.Field("source", fields=["title_de"])
+def complex_query(field):
+    return Query.regionQuery(region="09", fields=["id", "name", field])
 
-    statistic1 = dg.Field(
-        "WAHL09", args={"year": 2017}, fields=["value", "PART04", source]
+
+@pytest.fixture
+def more_complex_query(complex_query):
+    query = complex_query
+    source = Field("source", fields=["title_de"])
+    statistic2 = Field(
+        name="BEV001", args={"statistics": "R12612"}, fields=["value", "year", source]
     )
+    query.add_field(statistic2)
+    return query
 
-    statistic2 = dg.Field(
-        name="BEV001", args={"statistics": "R12612"}, fields=["value", "year"]
+
+@pytest.fixture
+def no_args_query():
+    field = Field(name="WAHL09", fields=["value"])
+    return Query.regionQuery(region="09", fields=["id", "name", field])
+
+
+@pytest.fixture
+def multiple_args_query():
+    statistic1 = Field(
+        name="BETR09",
+        args={"FRUNW2": ["FRUART0111", "FRUART0112"]},
+        fields=["FRUNW2", "value", "year"],
     )
-
-    return dg.Query(region="09", fields=["id", "name", statistic1, statistic2])
-
-
-def test_create_query_class_with_field_instance(query):
-    assert isinstance(query, dg.Query)
+    return Query.regionQuery(region="02", fields=[statistic1])
 
 
-def test_create_query_class_without_field_throws_error():
+@pytest.fixture
+def all_regions_query(field):
+    return Query.allRegionsQuery(parent="11", fields=["id", "name", field])
+
+
+@pytest.fixture
+def nuts_query(field):
+    return Query.allRegionsQuery(parent="11", nuts=3, fields=["id", "name", field])
+
+
+@pytest.fixture
+def lau_query(field):
+    return Query.allRegionsQuery(parent="11", lau=3, fields=["id", "name", field])
+
+
+def test_create_query_is_class_query(query):
+    assert isinstance(query, Query)
+
+
+def test_create_query_class_without_start_filed_raises_error():
     with pytest.raises(TypeError):
-        dg.Query()
+        Query()
 
 
 def test_basic_graphql_string(query):
     graphql_query = query.get_graphql_query()
     assert re.sub(" +", " ", graphql_query.replace("\n", " ")) == re.sub(
-        " +",
-        " ",
-        """
-                {
-                    region(id: "09") {
-                    BEV001
-                    }
-                }
-                    """.replace(
-            "\n", " "
-        ),
+        " +", " ", """{region(id: "09"){BEV001 }}""".replace("\n", " ")
     )
 
 
 def test_get_fields_to_query():
-    field = dg.Field(name="WAHL09", args={"year": 2017}, fields=["value", "PART04"])
-    query = dg.Query(region="09", fields=[field])
-    subfields_string = query._get_fields_to_query()
+    field = Field(name="WAHL09", args={"year": 2017}, fields=["value", "PART04"])
+    subfields_string = field._get_fields_to_query(field)
     assert subfields_string == "WAHL09(year: 2017){value PART04 }"
 
 
-def test_get_complex_graphql_string():
-    field = dg.Field(name="WAHL09", args={"year": 2017}, fields=["value", "PART04"])
-    query = dg.Query(region="09", fields=["id", "name", field])
-    graphql_query = query.get_graphql_query()
-    assert re.sub(" +", " ", graphql_query.replace("\n", " ")) == re.sub(
-        " +",
-        " ",
-        """
-                {
-                    region(id: "09") {
-                    id name WAHL09(year: 2017){value PART04 }
-                    }
-                }
-                    """.replace(
-            "\n", " "
-        ),
-    )
-
-
-def test_get_complex_graphql_string_without_filter():
-    field = dg.Field(name="WAHL09", fields=["value"])
-    query = dg.Query(region="09", fields=["id", "name", field])
-    graphql_query = query.get_graphql_query()
-    assert re.sub(" +", " ", graphql_query.replace("\n", " ")) == re.sub(
-        " +",
-        " ",
-        """
-            {
-                region(id: "09") {
-                    id name WAHL09{value }
-                    }
-                }
-            """.replace(
-            "\n", " "
-        ),
-    )
-
-
-def test_get_multiple_stats(complex_query):
-
+def test_get_complex_graphql_string(complex_query):
     graphql_query = complex_query.get_graphql_query()
     assert re.sub(" +", " ", graphql_query.replace("\n", " ")) == re.sub(
-        " +",
-        " ",
-        """
-            {
-                region(id: "09") {
-                    id name WAHL09(year: 2017){value PART04 source{title_de } }
-                         BEV001(statistics: R12612){value year }
+        "    ",
+        "",
+        """{
+            region(id: "09"){
+                id name WAHL09(year: 2017){value year PART04 }
                 }
-            }
-            """.replace(
-            "\n", " "
+            }""".replace(
+            "\n", ""
         ),
     )
 
 
-def test_get_subfields(query):
-    assert query.get_fields() == ["BEV001"]
+def test_get_complex_graphql_string_without_args(no_args_query):
+    graphql_query = no_args_query.get_graphql_query()
+    assert re.sub(" +", " ", graphql_query.replace("\n", " ")) == re.sub(
+        "    ",
+        "",
+        """{
+        region(id: "09"){
+            id name WAHL09{value }}
+            }""".replace(
+            "\n", ""
+        ),
+    )
 
 
-def test_get_subfields_complex(complex_query):
-    assert complex_query.get_fields() == [
+def test_get_multiple_stats(more_complex_query):
+    graphql_query = more_complex_query.get_graphql_query()
+    assert re.sub(" +", " ", graphql_query.replace("\n", " ")) == re.sub(
+        "    ",
+        "",
+        """{
+        region(id: "09"){
+            id name WAHL09(year: 2017){value year PART04 }
+            BEV001(statistics: R12612){value year source{title_de }}}
+        }""".replace(
+            "\n", ""
+        ),
+    )
+
+
+def test_get_all_fields(query):
+    assert query.get_fields() == ["region", "BEV001"]
+
+
+def test_get_all_fields_complex(more_complex_query):
+    assert more_complex_query.get_fields() == [
+        "region",
         "id",
         "name",
         "WAHL09",
         "value",
+        "year",
         "PART04",
-        "source",
-        "title_de",
         "BEV001",
         "value",
         "year",
+        "source",
+        "title_de",
     ]
 
 
-def test_multiple_filter_args():
-    statistic1 = dg.Field(
-        name="BETR09",
-        args={"FRUNW2": ["FRUART0111", "FRUART0112"]},
-        fields=["FRUNW2", "value", "year"],
-    )
-
-    query = dg.Query(region="02", fields=[statistic1])
-    graphql_query = query.get_graphql_query()
-
+def test_multiple_filter_args(multiple_args_query):
+    graphql_query = multiple_args_query.get_graphql_query()
     assert re.sub(" +", " ", graphql_query.replace("\n", " ")) == re.sub(
-        " +",
-        " ",
-        """
-            {
-                region(id: "02") {
+        "    ",
+        "",
+        """{
+            region(id: "02"){
                 BETR09(FRUNW2: [FRUART0111, FRUART0112]){FRUNW2 value year }
                 }
-            }
-                """.replace(
-            "\n", " "
-        ),
-    )
-
-
-def test_filter_for_all_subtypes():
-    assert True
-
-
-def test_all_regions():
-    statistic1 = dg.Field(
-        name="WAHL09",
-        args={"year": 2017, "PART04": "B90_GRUENE"},
-        fields=["value", "year", "PART04"],
-    )
-
-    query = dg.Query(parent="11", fields=["id", "name", statistic1])
-    graphql_query = query.get_graphql_query()
-    assert re.sub(" +", " ", graphql_query.replace("\n", "")) == re.sub(
-        " +",
-        " ",
-        """
-                {
-                    allRegions(page: $page, itemsPerPage:$itemsPerPage) {
-                        regions(parent: "11") {
-                            id name WAHL09(year: 2017, PART04:
-                            B90_GRUENE){value year PART04 }
-                        }
-                        page
-                        itemsPerPage
-                        total
-                    }
-                }
-                """.replace(
+            }""".replace(
             "\n", ""
         ),
     )
 
 
-def test_nuts():
-    statistic1 = dg.Field(
-        name="WAHL09",
-        args={"year": 2017, "PART04": "B90_GRUENE"},
-        fields=["value", "year", "PART04"],
-    )
+def test_all_regions(all_regions_query):
 
-    query = dg.Query(parent="11", nuts=3, fields=["id", "name", statistic1])
-    graphql_query = query.get_graphql_query()
-    assert re.sub(" +", " ", graphql_query.replace("\n", "")) == re.sub(
-        " +",
-        " ",
-        """
-                {
-                    allRegions(page: $page, itemsPerPage:$itemsPerPage) {
-                        regions(parent: "11", nuts: 3) {
-                            id name WAHL09(year: 2017, PART04:
-                            B90_GRUENE){value year PART04 }
-                        }
-                        page
-                        itemsPerPage
-                        total
-                    }
+    graphql_query = all_regions_query.get_graphql_query()
+    assert re.sub(" +", " ", graphql_query.replace("\n", " ")) == re.sub(
+        "    ",
+        "",
+        """{
+            allRegions(page: $page, itemsPerPage: $itemsPerPage){
+                regions(parent: "11"){
+                    id name WAHL09(year: 2017){
+                        value year PART04 }
                 }
-                """.replace(
+                page itemsPerPage total }
+        }""".replace(
             "\n", ""
         ),
     )
 
 
-def test_lau():
-    statistic1 = dg.Field(
-        name="WAHL09",
-        args={"year": 2017, "PART04": "B90_GRUENE"},
-        fields=["value", "year", "PART04"],
+def test_nuts(nuts_query):
+    query = nuts_query
+    graphql_query = query.get_graphql_query()
+    assert re.sub(" +", " ", graphql_query.replace("\n", " ")) == re.sub(
+        "    ",
+        "",
+        """{
+            allRegions(page: $page, itemsPerPage: $itemsPerPage){
+                regions(parent: "11", nuts: 3){
+                    id name WAHL09(year: 2017){value year PART04 }
+                }
+                page itemsPerPage total }
+        }""".replace(
+            "\n", ""
+        ),
     )
 
-    query = dg.Query(parent="11", lau=3, fields=["id", "name", statistic1])
+
+def test_lau(lau_query):
+    query = lau_query
     graphql_query = query.get_graphql_query()
-    assert re.sub(" +", " ", graphql_query.replace("\n", "")) == re.sub(
-        " +",
-        " ",
-        """
-                {
-                    allRegions(page: $page, itemsPerPage:$itemsPerPage) {
-                        regions(parent: "11", lau: 3) {
-                            id name WAHL09(year: 2017, PART04:
-                            B90_GRUENE){value year PART04 }
-                        }
-                        page
-                        itemsPerPage
-                        total
-                    }
+    assert re.sub(" +", " ", graphql_query.replace("\n", " ")) == re.sub(
+        "    ",
+        "",
+        """{
+            allRegions(page: $page, itemsPerPage: $itemsPerPage){
+                regions(parent: "11", lau: 3){
+                    id name WAHL09(year: 2017){value year PART04 }
                 }
-                """.replace(
+                page itemsPerPage total }
+        }""".replace(
             "\n", ""
         ),
     )
 
 
 def test_filter_for_all(query):
-    field = dg.Field(
+    field = Field(
         name="WAHL09", args={"year": 2017, "PART04": "ALL"}, fields=["value", "PART04"]
     )
-    query = dg.Query(region="09", fields=["id", "name", field])
+    query = Query.regionQuery(region="09", fields=["id", "name", field])
     graphql_query = query.get_graphql_query()
-    assert re.sub(" +", " ", graphql_query.replace("\n", "")) == re.sub(
-        " +",
-        " ",
-        """
-            { region(id: "09") {
-                id
-                name
-                WAHL09(year: 2017, filter:{ PART04: { nin: []}}){value PART04 }
+    assert re.sub(" +", " ", graphql_query.replace("\n", " ")) == re.sub(
+        "    ",
+        "",
+        """{
+            region(id: "09"){
+                id name WAHL09(
+                    year: 2017, filter:{ PART04: { nin: []}}){
+                        value PART04 }
                 }
-            }
-                    """.replace(
+        }""".replace(
             "\n", ""
         ),
     )
 
 
 def test_add_fields_stepwise():
-
-    query = dg.Query(region="11")
+    query = Query.regionQuery(region="11")
     statistic1 = query.add_field("BEV001")
     statistic1.add_field("year")
-    statistic2 = dg.Field(
+    statistic2 = Field(
         name="WAHL09", args={"year": 2017, "PART04": "ALL"}, fields=["value", "PART04"]
     )
     query.add_field(statistic2)
 
-    assert query == dg.Query(
+    assert query == Query.regionQuery(
         region="11",
         fields=[
-            dg.Field(name="BEV001", fields=[dg.Field(name="year")]),
-            dg.Field(
+            Field(name="BEV001", fields=[Field(name="year")]),
+            Field(
                 name="WAHL09",
                 args={"year": 2017, "PART04": "ALL"},
                 fields=["value", "PART04"],
@@ -295,32 +259,28 @@ def test_add_fields_stepwise():
         ],
     )
 
-    query_string = query.get_graphql_query()
-    assert re.sub(" +", " ", query_string.replace("\n", " ")) == re.sub(
-        " +",
-        " ",
-        """
-            {
-                region(id: "11") {
+    graphql_query = query.get_graphql_query()
+    assert re.sub(" +", " ", graphql_query.replace("\n", " ")) == re.sub(
+        "    ",
+        "",
+        """{
+                region(id: "11"){
                     BEV001{year}
                     WAHL09(year: 2017, filter:{ PART04: { nin: []}}){value PART04 }
                 }
-            }
-            """.replace(
-            "\n", " "
+        }""".replace(
+            "\n", ""
         ),
     )
 
 
 def test_add_args_stepwise():
-    query = dg.Query(region="11")
+    query = Query.regionQuery(region="11")
     statistic1 = query.add_field("BEV001")
     statistic1.add_field("year")
     statistic1.add_args({"year": 2017})
 
-    assert query == dg.Query(
+    assert query == Query.regionQuery(
         region="11",
-        fields=[
-            dg.Field(name="BEV001", args={"year": 2017}, fields=[dg.Field(name="year")])
-        ],
+        fields=[Field(name="BEV001", args={"year": 2017}, fields=[Field(name="year")])],
     )

--- a/tests/test_unittests.py
+++ b/tests/test_unittests.py
@@ -228,3 +228,40 @@ def test_get_type_info_uses_cached_resutls(type_request_response):
     res = qe.get_type_info("BEVMK3Statistics")
     assert res == expected_result
     qe._send_request.assert_not_called()
+
+    def test_QueryExecutionerWorkflow(sample_queries):
+        qExec = QueryExecutioner()
+
+        assert (
+            qExec.endpoint == "https://api-next.datengui.de/graphql"
+        ), "Default endpoint is wrong"
+
+        res_query1 = qExec.run_query(sample_queries.data_query1)
+        assert res_query1 is not None, "query did not return results"
+
+        assert len(res_query1.query_results) > 0, "query did not return results"
+        assert (
+            type(res_query1.query_results) is dict
+        ), "query results are not a python json representation"
+
+        assert type(res_query1.meta_data) == dict, "meta data not a dict"
+        assert len(res_query1.meta_data) > 0, "meta data absent"
+        assert len(res_query1.meta_data) == 1, "too much meta data"
+
+        assert "BEVMK3" in res_query1.meta_data, "statistic absend"
+        assert (
+            res_query1.meta_data["BEVMK3"] != "NO DESCRIPTION FOUND"
+        ), "descrption was not obtained"
+
+        info = qExec.get_type_info("Region")
+        assert info.kind == "OBJECT", "Region should be an object"
+        assert info.enum_values is None, "Region doesn't have enum values"
+        assert type(info.fields) == dict, "Fields should be a dict"
+
+        stat_args = info.fields["BEVMK3"].get_arguments()
+        assert len(stat_args) > 0
+        assert "statistics" in stat_args
+
+        enum_vals = qExec.get_type_info("BEVMK3Statistics").enum_values
+        assert type(enum_vals) == dict, "Enum values should be dict"
+        assert len(enum_vals) > 0, "Enums should have values"


### PR DESCRIPTION
add default values to Query (id, name) and Fields (value, year, source) if "default_values" is not set to False.

Include the return_type as an argument for fields to properly query meta data on the field (also needed to determine if field is a statistic and default values need to be added.)

this also includes a "get_info" method which is only masking the functionality of the Query_Executioner.