### PR TITLE
increaded the version to 0.2.1 for the next relesae

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -12,9 +12,12 @@ History
 
 * Cleanup of the first release regarding naming, authors and docs.
 
-0.2.0 (2020-05-17)
+0.2.0 (2020-11-30)
 ------------------
 
 * Added functionality to use meta data for displaying descriptive statistics names and enum values
+
+0.2.1 (2020-05-17)
+------------------
 * Added functionality to display the units of a statistic along with the numerical value.
 * Internally split the meta data extraction into technical meta data and meta data about the statistics. Implemented new defaults for the statistics meta data in order to account for changes in the datenguide API.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.2.0
+current_version = 0.2.1
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ test_requirements = ["pytest"]
 
 setup(
     name="datenguidepy",
-    version="0.2.0",
+    version="0.2.1",
     packages=find_packages(include=["datenguidepy"]),
     author="CorrelAid",
     author_email="packages@correlaid.org",


### PR DESCRIPTION
Another version update, as the prior merge of verion 0.2.0 was, outstanding to be merged into master but already updated on pypi back in november 19. As such new releases need a new version.