### PR TITLE
Datenguide for python38

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@
 dist: xenial
 language: python
 python:
+  - 3.8
   - 3.7
   - 3.6
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,9 @@
 [tox]
-envlist =  py36, py37, flake8
+envlist =  py36, py37, py38, flake8
 
 [travis]
 python =
+    3.8: py38
     3.7: py37
     3.6: py36
 


### PR DESCRIPTION
Extended tox.ini and .travis.yaml files to include python 3.8 in their configuration for testing. Related to issue #74 

Most importantly this will run travis-ci for all python versions. Dev testing on one's local machine can still be simplified by restricting to one environment (e.g. tox -e py36). This will give a good impression of possible issues most of the time, as we don't expect major python version issues. But even in case they should arise, travis will spot them afterwards when committed to github.