### PR TITLE
update packages

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,5 +14,7 @@ dependencies:
   - pip
   - python=3.7
   - plotly
+  - geopandas
+  - geoviews
   - pip:
     - git+https://github.com/CorrelAid/datenguide-python.git

--- a/environment.yml
+++ b/environment.yml
@@ -2,15 +2,17 @@ name: datenguide
 channels:
   - conda-forge
   - defaults
+  - plotly
 dependencies:
-  - ipython
-  - jupyter 
+  # - ipython
+  # - jupyter 
   - matplotlib
   - seaborn
-  - mkl
+  # - mkl
   - numpy
   - pandas>=0.25
   - pip
   - python=3.7
+  - plotly
   - pip:
     - git+https://github.com/CorrelAid/datenguide-python.git


### PR DESCRIPTION
- remove unnecessary jupyter packages
- add plotly dependency for tutorials

[Try on binder](https://mybinder.org/v2/gh/CorrelAid/datenguide-python/binder)

- the badge on the main branch to binder should continue working once this is merged.